### PR TITLE
Fix greedy scheduler bug.

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -191,7 +191,7 @@ def schedule_graph(G, scheduler, metadata):
     # could move the tasks themselves - in this case, push things into the future).
     for task in G.nodes:
         if task.start_date is not None and task.end_date is not None:
-            scheduler(G, task, False, metadata)
+            scheduler(G, task, True, metadata)
 
     # Now, back propagate dates (so end dates can be based on start dates of successor tasks).
     #


### PR DESCRIPTION
The first pass which assigns people to dates based on manually scheduled tasks needs to make those assignments in the “backwards” calendar so there won’t be conflicts generated in the backwards pass. We only expect conflicts from the forward pass, since it starts by scheduling root tasks to start today (and uses a separate calendar because having tasks just slide past the end of everything else isn’t as useful as seeing the immediate conflicts between “start now” and “finish by X”.