### PR TITLE
Better Ongoing / Rolling Project

### DIFF
--- a/backend/dateutil.py
+++ b/backend/dateutil.py
@@ -12,3 +12,9 @@ def compare_busdays(start, end, estimate):
 
 def busdays_offset(date, days):
     return np.busday_offset(date, days, roll='forward').astype(datetime)
+
+def date_to_offset(maybe_date, today):
+    if isinstance(maybe_date, int):
+        return maybe_date
+    else:
+        return busdays_between(today, maybe_date)

--- a/backend/milp_test.py
+++ b/backend/milp_test.py
@@ -250,11 +250,29 @@ class TestScheduler(unittest.TestCase):
             tasks=[
                 {"name": "Task1", "estimate": 2},
                 {"name": "Task2", "estimate": 3, "latest_end": 2},
-                {"name": "Task3", "estimate": 1}
+                {"name": "Task3", "estimate": 1, "latest_end": 3}
             ],
             dependencies=[],
             people=["Alice"],
-            expected_infeasible=True  # Cannot complete 2 (3 units) by time 3 if we start at 0
+            # We allow estimates and end dates before completion, 
+            # we just take it to mean an item that's either in progress
+            # or non-negotiable to happen now
+            expected_infeasible=False
+        )
+        self.run_scenario(scenario)
+
+    def test_latest_end_constraint(self):
+        scenario = TestScenario(
+            tasks=[
+                {"name": "Task1", "estimate": 2},
+                {"name": "Task2", "estimate": 3, "latest_end": 2},
+                {"name": "Task3", "estimate": 1, "latest_end": 2}
+            ],
+            dependencies=[],
+            people=["Alice"],
+            # Cannot complete task 2 ( 3 units) and task 3 ( 1 unit ) by 
+            # time 2, even with the adjustments
+            expected_infeasible=True
         )
         self.run_scenario(scenario)
 

--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -248,7 +248,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     fit: true,
                     center: true,
                     zoomScaleSensitivity: .5,
-                    minZoom: .1,
+                    minZoom: .7,
                     maxZoom: 7,
                 });
 


### PR DESCRIPTION
Broadly, this change is aimed at support for ongoing / rolling projects. Prior to this change, projects would quickly become problematic for the optimizer, since it would roll the window back to accommodate all start dates.

Now, we will run a pruning step before optimizing which:
1. Removes all tasks with end date before "today" from the optimization.
2. When start < today < end, adjust estimate to end - today and include in the optimization.

The normal highlighting Fantasia provides after the fact will still work, but it forces the PM to keep the project up to date. The only problematic case is where start and end date are before today but we want it included in the optimization. In these cases, they'll be highlighted red ( since the optimization will not force itself to step backward to include them ), but the user is forced to set an end date later than today to have it included, which they should since it's not finished.